### PR TITLE
fix: disable GATT service cache after failed update

### DIFF
--- a/custom_components/pax_levante/pax_client.py
+++ b/custom_components/pax_levante/pax_client.py
@@ -85,13 +85,17 @@ class PaxSensors:
 
 
 class PaxClient:
-    def __init__(self, device):
+    def __init__(self, device, use_services_cache=True):
         self._device = device
         self._client = None
+        self._use_services_cache = use_services_cache
 
     async def __aenter__(self):
         self._client = await establish_connection(
-            BleakClient, self._device, self._device.name or "Pax Levante"
+            BleakClient,
+            self._device,
+            self._device.name or "Pax Levante",
+            use_services_cache=self._use_services_cache,
         )
         return self
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -27,9 +27,8 @@ def auto_enable_custom_integrations(enable_custom_integrations):
 
 
 class MockClient:
-    def __init__(self, bleDevice):
+    def __init__(self, bleDevice, use_services_cache=True):
         self.bleDevice = bleDevice
-        pass
 
     device = PaxDevice(
         manufacturer="Pax",


### PR DESCRIPTION
## Summary

- After a BLE connection timeout, the BlueZ D-Bus cached GATT service table can become incomplete, causing `Characteristic 528b80e8-... was not found!` errors that never recover
- Tracks update failures via `_last_update_failed` flag and forces fresh GATT service discovery (`use_services_cache=False`) on the next connection attempt
- Reverts to using the cache on success, keeping normal operation fast

## Test plan

- [x] Existing unit tests pass (`test_pax_client.py` - 5/5 passing)
- [ ] Deploy to Home Assistant and monitor logs — after a timeout, the next update should recover by forcing fresh service discovery
- [ ] Verify normal polling performance is unaffected (cache used when no prior failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)